### PR TITLE
Add an environment spec file

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -1,0 +1,18 @@
+name: yams
+channels:
+  - conda-forge
+  - ssg-aero
+dependencies:
+  - cxx-compiler
+  - cmake
+  - ninja
+  - rapidjson
+  - xtensor
+  - xsimd
+  - eigen
+  - vtk
+  - gbs
+  - python=3.9
+  - pybind11
+  - pytest
+  - sel(win): vs2019_win-64


### PR DESCRIPTION
Description
---

Add an environment spec file:
 - list dependencies to easily create a fresh env to build the project
- use a mamba selector for `vs2019_win-64` to get `C++20` support
  - will not work with `conda` but only with `mamba` or `micromamba` (it will just skip the dependency and only install `vs2017_win-64`)